### PR TITLE
feat: update orphan command to handle limits and enhance output format

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -38,4 +38,48 @@ $ backstage-api facet get --facet spec.lifecycle --pretty
 
 ```bash
 backstage-api orphan list
+
+[
+  {
+    "metadata": {
+      "namespace": "default",
+      "annotations": {
+        "backstage.io/managed-by-location": "url:xxxxxx",
+        "backstage.io/managed-by-origin-location": "url:xxxxxx",
+        "backstage.io/view-url": "xxxxxx",
+        "backstage.io/edit-url": "xxxxxx",
+        "backstage.io/source-location": "url:xxxxxx",
+        "backstage.io/orphan": "true"
+      },
+      "name": "qwerty",
+      "uid": "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+      "etag": "xxxxxx"
+    },
+    "apiVersion": "backstage.io/v1alpha1",
+    "kind": "Component",
+    "spec": {
+      "type": "service",
+      "owner": "user:guest",
+      "lifecycle": "experimental"
+    },
+    "relations": [
+      {
+        "type": "ownedBy",
+        "targetRef": "user:default/guest"
+      }
+    ]
+  }
+]
 ```
+
+```bash
+$ backstage-api orphan list --pretty
+
++-------------+--------+-------------+
+| Kind        | Name   | Owner       |
++-------------+--------+-------------+
+| Component   | qwerty | user:guest  |
++-------------+--------+-------------+
+```
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backstage-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backstage-api",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A CLI tool to interact with Backstage API",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This pull request introduces enhancements to the `orphan` command, updates the documentation with new examples, and increments the package version. The key changes include improving how orphan entities are fetched and displayed, adding detailed examples to the documentation, and updating the version in `package.json`.

### Enhancements to the `orphan` command:
* Added a `limit` variable to control the maximum number of orphan entities fetched, defaulting to `Number.MAX_SAFE_INTEGER` if not specified.
* Updated the logic to handle empty `items` arrays gracefully and ensure only the required number of entities are processed based on the limit.
* Enhanced the output formatting by replacing `orphan.spec.owner` with `entity.spec?.owner` for better reliability and added a summary of the total orphan entities when using the `--pretty` option.
* Changed the error handling to terminate the process with a non-zero exit code on failure.

### Documentation updates:
* Added detailed examples for the `orphan` command in `docs/examples.md`, showcasing both JSON and table outputs for better clarity.

### Version update:
* Incremented the package version from `1.0.0` to `1.0.1` in `package.json` to reflect the changes.