### PR TITLE
feat: add catalog command

### DIFF
--- a/commands/catalog.js
+++ b/commands/catalog.js
@@ -1,0 +1,195 @@
+const { Command } = require('commander');
+const apiClient = require('../apiClient');
+const Table = require('cli-table3');
+
+const catalog = new Command('catalog');
+
+catalog
+  .command('refresh')
+  .description('Refresh an entity in the Backstage catalog')
+  .requiredOption('-e, --entity-ref <entityRef>', 'Entity reference in the format kind:namespace/name')
+  .action(async (options) => {
+    try {
+      const { entityRef } = options;
+      
+      console.log(`🔄 Refreshing entity: ${entityRef}...`);
+      
+      const res = await apiClient.post('/catalog/refresh', {
+        entityRef,
+      }, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      });
+      
+      if (res.status >= 200 && res.status < 300) {
+        console.log('✅ Entity refresh request submitted successfully!');
+        
+        if (res.data) {
+          console.log('\nResponse details:');
+          console.log(JSON.stringify(res.data, null, 2));
+        }
+      } else {
+        console.error(`❌ Request failed with status: ${res.status}`);
+      }
+    } catch (err) {
+      console.error('💥 Error refreshing entity:', err.message);
+      if (err.response) {
+        console.error(`Status: ${err.response.status}`);
+        console.error('Details:', JSON.stringify(err.response.data, null, 2));
+      }
+      process.exit(1);
+    }
+  });
+
+// Get entity by name subcommand
+catalog
+  .command('get-by-name')
+  .description('Get an entity by name from the Backstage catalog')
+  .requiredOption('-k, --kind <kind>', 'Entity kind (e.g., Component, API, System)')
+  .requiredOption('-n, --name <name>', 'Entity name')
+  .requiredOption('-s, --namespace <namespace>', 'Entity namespace (e.g., default)')
+  .option('-p, --pretty', 'Pretty-print the output in table format')
+  .action(async (options) => {
+    try {
+      const { kind, name, namespace } = options;
+      
+      if (options.pretty) {
+        console.log(`🔍 Looking up entity: ${kind}:${namespace}/${name}...`);
+      }
+      
+      const res = await apiClient.get(`/catalog/entities/by-name/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`, {
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+      
+      if (res.status >= 200 && res.status < 300) {
+        if (options.pretty) {
+          console.log('✅ Entity found!');
+          
+          const entity = res.data;
+          
+          console.log('\n📋 Entity Details:\n');
+          
+          const infoTable = new Table();
+          
+          infoTable.push(
+            { 'Kind': entity.kind || 'N/A' },
+            { 'Name': entity.metadata?.name || 'N/A' },
+            { 'Namespace': entity.metadata?.namespace || 'N/A' },
+            { 'Title': entity.metadata?.title || 'N/A' },
+            { 'Description': entity.metadata?.description || 'N/A' },
+            { 'Owner': entity.spec?.owner || 'N/A' },
+            { 'Type': entity.spec?.type || 'N/A' },
+            { 'Lifecycle': entity.spec?.lifecycle || 'N/A' }
+          );
+          
+          console.log(infoTable.toString());
+          
+          // Show annotations if present
+          if (entity.metadata?.annotations && Object.keys(entity.metadata.annotations).length > 0) {
+            console.log('\n📝 Annotations:');
+            const annotationsTable = new Table({
+              head: ['Key', 'Value'],
+              colWidths: [40, 50],
+            });
+            
+            Object.entries(entity.metadata.annotations).forEach(([key, value]) => {
+              annotationsTable.push([key, value]);
+            });
+            
+            console.log(annotationsTable.toString());
+          }
+          
+          // Show relations if present
+          if (entity.relations && entity.relations.length > 0) {
+            console.log('\n🔄 Relations:');
+            const relationsTable = new Table({
+              head: ['Type', 'Target'],
+              colWidths: [20, 60],
+            });
+            
+            entity.relations.forEach((relation) => {
+              relationsTable.push([relation.type, relation.targetRef]);
+            });
+            
+            console.log(relationsTable.toString());
+          }
+        } else {
+          console.log(JSON.stringify(res.data, null, 2));
+        }
+      } else {
+        if (options.pretty) {
+          console.error(`❌ Request failed with status: ${res.status}`);
+        } else {
+          console.log(JSON.stringify({
+            error: true,
+            status: res.status,
+            message: `Request failed with status: ${res.status}`
+          }, null, 2));
+        }
+      }
+    } catch (err) {
+      if (options.pretty) {
+        console.error('💥 Error fetching entity:', err.message);
+        if (err.response) {
+          console.error(`Status: ${err.response.status}`);
+          console.error('Details:', JSON.stringify(err.response.data, null, 2));
+        }
+      } else {
+        console.log(JSON.stringify({
+          error: true,
+          message: err.message,
+          status: err.response?.status,
+          details: err.response?.data
+        }, null, 2));
+      }
+      process.exit(1);
+    }
+  });
+
+// Create location subcommand
+catalog
+  .command('create-location')
+  .description('Create a location to import a component into the Backstage catalog')
+  .requiredOption('-t, --target <target>', 'Target URL of the component to import')
+  .action(async (options) => {
+    try {
+      const { target } = options;
+      const type = 'url';
+      
+      console.log(`📝 Creating location for target: ${target}...`);
+      
+      const res = await apiClient.post('/catalog/locations', {
+        target,
+        type
+      }, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      });
+      
+      if (res.status >= 200 && res.status < 300) {
+        console.log('✅ Location created successfully!');
+        
+        if (res.data) {
+          console.log('\nLocation details:');
+          console.log(JSON.stringify(res.data, null, 2));
+        }
+      } else {
+        console.error(`❌ Request failed with status: ${res.status}`);
+      }
+    } catch (err) {
+      console.error('💥 Error creating location:', err.message);
+      if (err.response) {
+        console.error(`Status: ${err.response.status}`);
+        console.error('Details:', JSON.stringify(err.response.data, null, 2));
+      }
+      process.exit(1);
+    }
+  });
+
+module.exports = catalog;

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -83,3 +83,108 @@ $ backstage-api orphan list --pretty
 ```
 
 ---
+
+## 📚 `catalog` Command
+
+### 🔄 `catalog refresh` Command
+
+```bash
+$ backstage-api catalog refresh --entity-ref component:default/my-service
+
+🔄 Refreshing entity: component:default/my-service...
+✅ Entity refresh request submitted successfully!
+```
+
+### 🔍 `catalog get-by-name` Command
+
+```bash
+$ backstage-api catalog get-by-name --kind Component --name my-service --namespace default
+
+🔍 Looking up entity: Component:default/my-service...
+✅ Entity found!
+
+Entity details:
+{
+  "metadata": {
+    "namespace": "default",
+    "annotations": {
+      "backstage.io/managed-by-location": "url:https://github.com/example/repo/blob/master/catalog-info.yaml",
+      "backstage.io/managed-by-origin-location": "url:https://github.com/example/repo/blob/master/catalog-info.yaml",
+      "backstage.io/view-url": "https://github.com/example/repo/blob/master/catalog-info.yaml",
+      "backstage.io/edit-url": "https://github.com/example/repo/edit/master/catalog-info.yaml"
+    },
+    "name": "my-service",
+    "uid": "12345-abcde-67890-fghij",
+    "etag": "abc123def456"
+  },
+  "apiVersion": "backstage.io/v1alpha1",
+  "kind": "Component",
+  "spec": {
+    "type": "service",
+    "lifecycle": "production",
+    "owner": "team:engineering"
+  },
+  "relations": [
+    {
+      "type": "ownedBy",
+      "targetRef": "group:default/engineering"
+    }
+  ]
+}
+```
+
+```bash
+$ backstage-api catalog get-by-name --kind Component --name my-service --namespace default --pretty
+
+🔍 Looking up entity: Component:default/my-service...
+✅ Entity found!
+
+📋 Entity Details:
+
+┌────────────┬─────────────────┐
+│ Kind       │ Component       │
+├────────────┼─────────────────┤
+│ Name       │ my-service      │
+├────────────┼─────────────────┤
+│ Namespace  │ default         │
+├────────────┼─────────────────┤
+│ Title      │ N/A             │
+├────────────┼─────────────────┤
+│ Description│ N/A             │
+├────────────┼─────────────────┤
+│ Owner      │ team:engineering│
+├────────────┼─────────────────┤
+│ Type       │ service         │
+├────────────┼─────────────────┤
+│ Lifecycle  │ production      │
+└────────────┴─────────────────┘
+
+📝 Annotations:
+┌───────────────────────────────────────────┬──────────────────────────────────────────────────────────────────┐
+│ Key                                       │ Value                                                            │
+├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ backstage.io/managed-by-location          │ url:https://github.com/example/repo/blob/master/catalog-info.yaml│
+├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ backstage.io/managed-by-origin-location   │ url:https://github.com/example/repo/blob/master/catalog-info.yaml│
+├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ backstage.io/view-url                     │ https://github.com/example/repo/blob/master/catalog-info.yaml    │
+├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ backstage.io/edit-url                     │ https://github.com/example/repo/edit/master/catalog-info.yaml    │
+└───────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┘
+
+🔄 Relations:
+┌──────────┬──────────────────────────┐
+│ Type     │ Target                   │
+├──────────┼──────────────────────────┤
+│ ownedBy  │ group:default/engineering│
+└──────────┴──────────────────────────┘
+```
+
+### 🌍 `catalog create-location` Command
+
+```bash
+$ backstage-api catalog create-location --target https://github.com/org/repo/blob/master/catalog-info.yaml
+
+📝 Creating location for target: https://github.com/org/repo/blob/master/catalog-info.yaml...
+✅ Location created successfully!
+```

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -30,13 +30,13 @@ Options:
 
 ---
 
-# 🧭 `orphan` Command
+## 🧭 `orphan` Command
 
 The `orphan` command lets you list all orphaned entities in your Backstage catalog — these are entities not connected to any location, often leftovers or mistakes.
 
 ---
 
-## 🔧 Usage
+### 🔧 Usage
 
 ```bash
 backstage-api orphan list --help
@@ -50,3 +50,74 @@ Options:
   -l, --limit <number>  Limit the number of results returned
   -h, --help            display help for command
 ```
+
+---
+
+## 📚 `catalog` Command
+
+The `catalog` command provides utilities for interacting with the Backstage catalog, allowing you to refresh entities and register new components through locations.
+
+---
+
+### 🔄 `catalog refresh` Command
+
+The `refresh` subcommand allows you to trigger a refresh of an entity in the Backstage catalog.
+
+#### 🔧 Usage
+
+```bash
+$ backstage-api catalog refresh --help
+
+Usage: backstage-api catalog refresh [options]
+
+Refresh an entity in the Backstage catalog
+
+Options:
+  -e, --entity-ref <entityRef>  Entity reference in the format kind:namespace/name
+  -h, --help                    display help for command
+```
+---
+
+### 🔍 `catalog get-by-name` Command
+
+The `get-by-name` subcommand allows you to retrieve detailed information about a specific entity using its kind, namespace, and name.
+
+#### 🔧 Usage
+
+```bash
+$ backstage-api catalog get-by-name --help
+
+Usage: backstage-api catalog get-by-name [options]
+
+Get an entity by name from the Backstage catalog
+
+Options:
+  -k, --kind <kind>              Entity kind (e.g., Component, API, System)
+  -n, --name <name>              Entity name
+  -s, --namespace <namespace>    Entity namespace (e.g., default)
+  -p, --pretty                   Pretty-print the output in table format
+  -h, --help                     display help for command
+```
+---
+
+### 🌍 `catalog create-location` Command
+
+The `create-location` subcommand registers a new component location in the Backstage catalog, allowing Backstage to discover and import components from external sources.
+
+#### 🔧 Usage
+
+```bash
+$ backstage-api catalog create-location --help
+
+Usage: backstage-api catalog create-location [options]
+
+Create a location to import a component into the Backstage catalog
+
+Options:
+  -t, --target <target>  Target URL of the component to import
+  -h, --help             display help for command
+```
+
+#### ✅ Notes
+
+- The `--target` parameter should be a URL pointing to a catalog-info.yaml file.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { version, name, author } = require('./package.json');
 const { Command } = require('commander');
 const facet = require('./commands/facet');
 const orphan = require('./commands/orphan');
+const catalog = require('./commands/catalog');
 
 const program = new Command();
 
@@ -14,5 +15,6 @@ program
 
 program.addCommand(facet);
 program.addCommand(orphan);
+program.addCommand(catalog);
 
 program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backstage-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backstage-api",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-api",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A CLI tool to interact with Backstage API",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This pull request introduces a new `catalog` command to the Backstage CLI, providing utilities for interacting with the Backstage catalog, such as refreshing entities, retrieving entity details, and creating component locations. Additionally, documentation has been updated to reflect these new features, and the CLI version has been incremented to `1.1.0`.

### New `catalog` Command Features:
* **`catalog refresh` Subcommand**: Allows users to refresh an entity in the Backstage catalog by specifying its entity reference in the format `kind:namespace/name`.
* **`catalog get-by-name` Subcommand**: Enables fetching detailed information about an entity using its kind, namespace, and name. Includes an option for pretty-printing the output in a table format.
* **`catalog create-location` Subcommand**: Provides functionality to register a new component location in the Backstage catalog, specifying the target URL of the component.

### Documentation Updates:
* **Examples (`docs/examples.md`)**: Added usage examples for the new `catalog` subcommands, including `refresh`, `get-by-name`, and `create-location`.
* **Manual (`docs/manual.md`)**: Expanded the manual with detailed descriptions, usage instructions, and options for the new `catalog` subcommands. [[1]](diffhunk://#diff-8b611c63a98d96b60454bca54304d95f3873e553cd56bed2663fa6b0a6eb8f2fL33-R39) [[2]](diffhunk://#diff-8b611c63a98d96b60454bca54304d95f3873e553cd56bed2663fa6b0a6eb8f2fR53-R123)

### Codebase Enhancements:
* **CLI Registration (`index.js`)**: Integrated the new `catalog` command into the CLI by adding it to the program's command list. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R7) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R18)
* **Version Update (`package.json`)**: Incremented the CLI version from `1.0.1` to `1.1.0` to reflect the addition of new features.